### PR TITLE
Flex and Xelisv2: Clang and Bionic compatibility

### DIFF
--- a/algo/flex/cryptonote/crypto/oaes_lib.c
+++ b/algo/flex/cryptonote/crypto/oaes_lib.c
@@ -35,7 +35,44 @@ static const char _NR[] = {
  
 #include <stddef.h>
 #include <time.h> 
+/*
 #include <sys/timeb.h>
+  ftime from timeb.h was removed in POSIX 2008 and there are
+  systems (Android's Bionic) that followed this move. All other
+  systems will hopefully work with this ftime() implementation.
+  Adapted from https://github.com/termux/termux-app/issues/1442
+ */
+#include <sys/time.h>
+struct timeb {
+	time_t time;
+	unsigned short int millitm;
+	short int timezone;
+	short int dstflag;
+};
+int ftime(struct timeb *tb)
+/*
+  This is not a full implementation of ftime(). It is lacking the
+  timezone handling, which may not always be correct on all platforms,
+  e.g. on Windows. Luckily it is not needed further down.
+  OTOH, calling gettimeofday() with a NULL pointer as 2nd argument
+  is POSIX compliant.
+ */
+{
+	struct timeval  tv;
+
+	if (gettimeofday (&tv, NULL) < 0)
+		return -1;
+
+	tb->time    = tv.tv_sec;
+	tb->millitm = (tv.tv_usec + 500) / 1000;
+
+	if (tb->millitm == 1000) {
+		++tb->time;
+		tb->millitm = 0;
+	}
+
+	return 0;
+}
 #ifdef __APPLE__
 #include <malloc/malloc.h>
 #else 

--- a/algo/flex/cryptonote/cryptonight.c
+++ b/algo/flex/cryptonote/cryptonight.c
@@ -4,8 +4,12 @@
 // Portions Copyright (c) 2018 The Monero developers
 // Portions Copyright (c) 2018 The TurtleCoin Developers
 
+#include "cpuminer-config.h"
 #include <stdio.h>
 #include <stdlib.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
 #include "crypto/oaes_lib.h"
 #include "crypto/c_keccak.h"
 #include "crypto/c_groestl.h"

--- a/algo/flex/cryptonote/cryptonight_dark.c
+++ b/algo/flex/cryptonote/cryptonight_dark.c
@@ -4,8 +4,12 @@
 // Portions Copyright (c) 2018 The Monero developers
 // Portions Copyright (c) 2018 The TurtleCoin Developers
 
+#include "cpuminer-config.h"
 #include <stdio.h>
 #include <stdlib.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
 #include "crypto/oaes_lib.h"
 #include "crypto/c_keccak.h"
 #include "crypto/c_groestl.h"

--- a/algo/flex/cryptonote/cryptonight_dark_lite.c
+++ b/algo/flex/cryptonote/cryptonight_dark_lite.c
@@ -4,8 +4,12 @@
 // Portions Copyright (c) 2018 The Monero developers
 // Portions Copyright (c) 2018 The darkCoin Developers
 
+#include "cpuminer-config.h"
 #include <stdio.h>
 #include <stdlib.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
 #include "crypto/oaes_lib.h"
 #include "crypto/c_keccak.h"
 #include "crypto/c_groestl.h"

--- a/algo/flex/cryptonote/cryptonight_fast.c
+++ b/algo/flex/cryptonote/cryptonight_fast.c
@@ -4,8 +4,12 @@
 // Portions Copyright (c) 2018 The Monero developers
 // Portions Copyright (c) 2018 The TurtleCoin Developers
 
+#include "cpuminer-config.h"
 #include <stdio.h>
 #include <stdlib.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
 #include "crypto/oaes_lib.h"
 #include "crypto/c_keccak.h"
 #include "crypto/c_groestl.h"
@@ -198,7 +202,11 @@ struct cryptonightfast_ctx {
 };
 
 void cryptonightfast_hash(const char* input, char* output, uint32_t len, int variant) {
-    struct cryptonightfast_ctx *ctx = malloc(sizeof(struct cryptonightfast_ctx));
+#if defined(_MSC_VER)
+    struct cryptonightfast_ctx *ctx = _malloca(sizeof(struct cryptonightfast_ctx));
+#else
+    struct cryptonightfast_ctx *ctx = alloca(sizeof(struct cryptonightfast_ctx));
+#endif
     hash_process(&ctx->state.hs, (const uint8_t*) input, len);
     memcpy(ctx->text, ctx->state.init, INIT_SIZE_BYTE);
     memcpy(ctx->aes_key, ctx->state.hs.b, AES_KEY_SIZE);
@@ -281,7 +289,6 @@ void cryptonightfast_hash(const char* input, char* output, uint32_t len, int var
     /*memcpy(hash, &state, 32);*/
     extra_hashes[ctx->state.hs.b[0] & 2](&ctx->state, 200, output);
     oaes_free((OAES_CTX **) &ctx->aes_ctx);
-    free(ctx);
 }
 
 void cryptonightfast_fast_hash(const char* input, char* output, uint32_t len) {

--- a/algo/flex/cryptonote/cryptonight_lite.c
+++ b/algo/flex/cryptonote/cryptonight_lite.c
@@ -4,8 +4,12 @@
 // Portions Copyright (c) 2018 The Monero developers
 // Portions Copyright (c) 2018 The TurtleCoin Developers
 
+#include "cpuminer-config.h"
 #include <stdio.h>
 #include <stdlib.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
 #include "crypto/oaes_lib.h"
 #include "crypto/c_keccak.h"
 #include "crypto/c_groestl.h"

--- a/algo/flex/cryptonote/cryptonight_soft_shell.c
+++ b/algo/flex/cryptonote/cryptonight_soft_shell.c
@@ -4,8 +4,12 @@
 // Portions Copyright (c) 2018 The Monero developers
 // Portions Copyright (c) 2018 The TurtleCoin Developers
 
+#include "cpuminer-config.h"
 #include <stdio.h>
 #include <stdlib.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
 #include "crypto/oaes_lib.h"
 #include "crypto/c_keccak.h"
 #include "crypto/c_groestl.h"

--- a/algo/flex/cryptonote/cryptonight_turtle.c
+++ b/algo/flex/cryptonote/cryptonight_turtle.c
@@ -4,8 +4,12 @@
 // Portions Copyright (c) 2018 The Monero developers
 // Portions Copyright (c) 2018 The TurtleCoin Developers
 
+#include "cpuminer-config.h"
 #include <stdio.h>
 #include <stdlib.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
 #include "crypto/oaes_lib.h"
 #include "crypto/c_keccak.h"
 #include "crypto/c_groestl.h"

--- a/algo/flex/cryptonote/cryptonight_turtle_lite.c
+++ b/algo/flex/cryptonote/cryptonight_turtle_lite.c
@@ -4,8 +4,12 @@
 // Portions Copyright (c) 2018 The Monero developers
 // Portions Copyright (c) 2018 The TurtleCoin Developers
 
+#include "cpuminer-config.h"
 #include <stdio.h>
 #include <stdlib.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
 #include "crypto/oaes_lib.h"
 #include "crypto/c_keccak.h"
 #include "crypto/c_groestl.h"

--- a/algo/xelisv2/aes.h
+++ b/algo/xelisv2/aes.h
@@ -87,7 +87,7 @@ static void add_round_key(uint8_t *state, const uint8_t *round_key) {
 }
 
 // AES Round Function
-inline void aes_single_round_no_intrinsics(uint8_t *state, const uint8_t *round_key) {
+static inline void aes_single_round_no_intrinsics(uint8_t *state, const uint8_t *round_key) {
     sub_bytes(state);
     shift_rows(state);
     mix_columns(state);

--- a/cpu-miner.c
+++ b/cpu-miner.c
@@ -3722,8 +3722,18 @@ BOOL WINAPI ConsoleHandler(DWORD dwType)
 static int thread_create(struct thr_info *thr, void* func)
 {
 	int err = 0;
+	size_t stack_size = 0;
 	pthread_attr_init(&thr->attr);
-	err = pthread_create(&thr->pth, &thr->attr, func, thr);
+	// as long as Cryptonight's scratchpad is on the stack, the stack
+	// needs to be large enough. cn and cn_fast are the largest with 2MB.
+	// Therefore, we add 2MB to the stack size. The Bionic C library
+	// needs this. Gnulibc usually doesn't but the orgiginal cn
+	// implementation suggested, Gnulibc did need it. It shouldn't hurt.
+	// Doing this ONLY when cn is needed is probably unnecessary.
+	err = pthread_attr_getstacksize(&thr->attr, &stack_size);
+	stack_size += 2097152;
+	err += pthread_attr_setstacksize(&thr->attr, stack_size);
+	err += pthread_create(&thr->pth, &thr->attr, func, thr);
 	pthread_attr_destroy(&thr->attr);
 	return err;
 }


### PR DESCRIPTION
Hi,
I've made your version compile on plain termux (without any Ubuntu under proot). It required a few changes which you can find in this pull request.
some notes:
- the "static" in the xelisv2/aes.h is a simple clang complaint
- _exit()  in the various cryptonight*.c is defined in unistd.h and Android's Bionic won't find it otherwise. For GCC and glibc it's cleaner this way
- ftime() is not defined in Bionic, so I used a simple implementation. This will probably not work with MSVC (but cpuminer does not work with it anyways). But it works with GCC and glibc.
- The biggest change is probably the increase of the stack size. Most cryptonight variants allocated a large chunk on the stack, but on Andorid's Bionic this stack is only 1MB. Only cryptonight_fast allocated the same space on the heap. Probably because in the original version the stack wasn't large enough. Now cryptonight_fast also uses the stack. This may even give a small performance increase :-) At least for my Android system, it did.

I've tested this with Android termux with Clang and with 2 different Linux systems with different GCCs.